### PR TITLE
use mathpunct spacing for the comma in pair expressions

### DIFF
--- a/mttex.sty
+++ b/mttex.sty
@@ -1076,7 +1076,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym.
 % #2 : A pre-formatted expression for the first component of the pair.
 % #3 : A pre-formatted expression for the second component of the pair.
-\newcommand{\@paire}[3]{#1{\langle}#2#1{,}#3{#1{\rangle}}}
+\newcommand{\@paire}[3]{#1{\langle} #2 \mathpunct{#1,} #3 {#1{\rangle}}}
 
 % \paire is like \@paire but provides a standard interface.
 %


### PR DESCRIPTION
Have you considered this change before? In my file it makes spacing of pairs look noticeably better in my eyes (it matters when the components are not just variables but for example function applications with spacing between them), but that's also a possibly invasive change for what I suppose to be a heavily-used command, and maybe you decided against it.
