### PR TITLE
define, use and document higher-level spacing macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ that "defs.tex" was practically empty.
 * [Language Symbol Macros](#language-symbol-macros)
 * [Language Combinators](#language-combinators)
 * [Meta-Theory Combinators](#meta-theory-combinators)
+* [Spacing](#spacing)
 
 ## Installation
 I recommend installing this package via git submodules until I figure
@@ -1138,4 +1139,72 @@ Like \maponeat but projects the second element.
 \maprelat[2]
 Like \maponeat but projects the third element, which is assumed to be a
 relation.
+```
+
+## Spacing
+
+To define meta-language combinators with consistent spacing, you are
+encouraged to liberally use the predefined LaTeX macros `\mathopen`,
+`\mathclose`, `\mathbin`, `\mathpunct` that determine character
+spacing. For example, our language combinator `\forallty` for
+polymorphic quantification ∀α.σ can be defined as follows:
+
+```latex
+% Formats a polymorphic type.
+%   #1 : A formatting macro for symbols, such as \tfontsym
+%   #2 : A formatting macro for text, such as \tfont
+%   #3 : The pre-formatted type-variable to bind
+%   #4 : The pre-formatted result in which the type-variable is bound
+\newcommand{\forallty}[4]{\mathopen{#1{\uplambda}} #3 \mathpunct{#1{.}} #4}
+```
+
+In addition, this package defines the macros `\maththinbin` and
+`\maththickbin` to use smaller and larger spacing than plain
+`\mathbin` around their arguments. `\maththinbin` is used around the
+colon of `\fune` (λ(x:σ).e), and `\maththickbin` is used around the
+vertical bar separating the two branches of a `\casee` statement (case
+e of x₁.e₁ | x₂.e₂).
+
+When defining language expression combinators, it is also common to
+use keywords instead of mathematical symbols: `let`, `in`, `if`,
+`then`, `else`, `pack`, `unfold`, etc. This package defines macros
+similar to the math spacing classes above: `\kwopen`, `\kwopen`,
+`\kwbin` and `\kwrel`. Finally, `\kwinfix` can be used for keywords
+used as infix operators (`pack`, `unfold`, etc.). See for example the
+following definitions:
+
+```latex
+% \packe: pack (σ,e) as ∃α.σ
+% #1 : A formatting macro for symbols, such as \tfontsym.
+% #2 : A formatting macro for text, such as \tfont.
+% #3 : A pre-formatted type witness.
+% #4 : A pre-formatted value witness.
+% #5 : A pre-formatted existential type abstracting the witness type.
+\newcommand{\packe}[5]{%
+  \kwopen{#2{pack}}%
+  \paire{#1}{#2}{#3}{#4}%
+  \kwbin{#2{as}}%
+  #5%
+}
+
+% \lete: let x = e in e'
+% #1 : A formatting macro for symbols, such as \tfontsym.
+% #2 : A formatting macro for text, such as \tfont.
+% #3 : A pre-formatted expression variable.
+% #4 : A pre-formatted expression to bind.
+% #5 : A pre-formatted body expression for the let.
+\newcommand{\lete}[5]{%
+  \kwopen{#2{let}}%
+  #3%
+  \mathbin{#1{=}}%
+  #4%
+  \kwbin{#2{in}}%
+  #5%
+}
+
+% \unfolde: unfold e
+% #1 : A formatting macro for symbols, such as \tfontsym.
+% #2 : A formatting macro for text, such as \tfont.
+% #3 : A pre-formatted expression of isorecursive type.
+\newcommand{\unfolde}[3]{\kwinfix{#2{unfold}} #3}
 ```

--- a/mttex.sty
+++ b/mttex.sty
@@ -379,8 +379,8 @@
 \newcommand{\ctxarrow}{\Rightarrow}
 
 % BNF symbols
-\newcommand{\bnfalt}{{\bf \,\,\mid\,\,}}
-\newcommand{\bnfdef}{{\bf ::=}}
+\newcommand{\bnfalt}{\mathrel{\bf \,\mid\,}}
+\newcommand{\bnfdef}{\mathrel{\bf ::=}}
 
 %% Language Formatting combinators
 
@@ -1305,7 +1305,7 @@
 %
 % #1 : Pre-formatted assumptions, such as \tfont{\Delta}
 % #2 : The pre-formatted proposition, such as \tfont{\alpha}
-\newcommand{\wf}[2]{#1~\!\!\vdash~\!\!#2}
+\newcommand{\wf}[2]{#1 \mathrel{\vdash} #2}
 
 % \judg formats a well-typedness judgment.
 % It takes 3 parameters.
@@ -1313,7 +1313,7 @@
 % #1 : The assumptions, such as \tfont{\Delta};\tfont{\Gamma}
 % #2 : The term, such as \tfont{e}
 % #3 : The type, such as \tfont{\tau}
-\newcommand{\judg}[3]{\wf{#1}{#2~\!\!:~\!\!#3}}
+\newcommand{\judg}[3]{\wf{#1}{#2 \mathrel{:} #3}}
 
 %% Context typing
 
@@ -1322,7 +1322,7 @@
 % #1 : A formatting macro for symbols, such as \stfontsym
 % #2 : The type of the hole
 % #3 : The type of the result
-\newcommand{\ctxarrowty}[3]{#2 \, #1{\ctxarrow} \, #3}
+\newcommand{\ctxarrowty}[3]{#2 \mathrel{#1{\ctxarrow}} #3}
 
 % \ctxty formats a context type, with different typing contexts for the
 % hole and result
@@ -1356,7 +1356,7 @@
 % #2 : A pre-formatted expression
 % #3 : A pre-formatted c.i.u. equivalent expression
 % #4 : A pre-formatted type for the expressions
-\newcommand{\ciueqvjudg}[4]{\judg{#1}{#2\,\ciueqvsym\,#3}{#4}}
+\newcommand{\ciueqvjudg}[4]{\judg{#1}{#2 \mathrel{\ciueqvsym} #3}{#4}}
 
 % \ctxeqvjudg formats a contextual equivalence judgment.
 %
@@ -1365,7 +1365,7 @@
 % #2 : A pre-formatted expression
 % #3 : A pre-formatted contextually equivalent expression
 % #4 : A pre-formatted type for the expressions
-\newcommand{\ctxeqvjudg}[4]{\judg{#1}{#2\,\ctxeqvsym\,#3}{#4}}
+\newcommand{\ctxeqvjudg}[4]{\judg{#1}{#2 \mathrel{\ctxeqvsym} #3}{#4}}
 
 %% Logical Relations
 \newcommand{\lratomsym}{\mrm{Atom}}

--- a/mttex.sty
+++ b/mttex.sty
@@ -743,8 +743,8 @@
 % #3 : The pre-formatted argument to the function
 % #4 : The pre-formatted result of the function
 \newcommand{\@polyfunty}[4]{%
-  \mathpunct{#1{\forall}}% or rather mathopen?
-  \mathopen{#1{[}}
+  \mathopen{#1{\forall}}%
+  \mathopen{#1{[}}%
   #2%
   \mathclose{#1{].}}\mathpunct{}%
   #3%
@@ -900,7 +900,7 @@
 % #4 : The pre-formatted type of the variable.
 % #5 : The pre-formatted body of the function.
 \newcommand{\@polyfune}[5]{
-  \mathpunct{#1{\uplambda}}% or rather mathopen? synch with polyfunty
+  \mathopen{#1{\uplambda}}%
   \mathopen{#1{[}}%
   #2%
   \mathclose{#1{]}}%

--- a/mttex.sty
+++ b/mttex.sty
@@ -682,6 +682,41 @@
 
 % TODO Figure out that currying issue with lists
 
+%%% Spacing commands
+%
+% See
+% http://tex.stackexchange.com/questions/38982/what-is-the-difference-between-mathbin-vs-mathrel
+% for a discussion of the default TeX space-affecting character
+% classes, namely
+%
+% \mathord: Ordinary (eg., /)
+% \mathop: Large operator (eg., \sum)
+% \mathbin: Binary operation (eg., +)
+% \mathrel: Relation (eg., =)
+% \mathopen: Opening (eg., ()
+% \mathclose: Closing (eg., ))
+% \mathpunct: Punctuation (eg., ,)
+
+% For language features, we often use "keywords" instead of
+% mathematical symbols: if,then,else,let,in,pack,unpack...
+%
+% It is customary to space these keywords differently, usually with
+% more space around them, as for natural language words. The
+% definitions below approximate the role of the character classes
+% above for keyword symbols.
+
+\newcommand{\kwopen}[1]{#1\,}
+\newcommand{\kwclose}[1]{,#1}
+\newcommand{\kwbin}[1]{\,#1\,}
+\newcommand{\kwrel}[1]{\mathrel{#1}}
+\newcommand{\kwinfix}[1]{#1\,}
+
+\newcommand{\maththinbin}[1]{\,#1\,}
+\newcommand{\maththickbin}[1]{\:#1\:}
+\newcommand{\@thickinfix}[1]{#1\:}
+
+\newcommand{\@quantifier}[4]{\mathopen{#1{#2}} #3 \mathpunct{#1{#4}}}
+
 %%% ----------------- Standard language features ----------------------
 
 %% ----------------------- Standard types ----------------------------
@@ -691,7 +726,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym
 % #2 : The pre-formatted argument to the function
 % #3 : The pre-formatted result of the function
-\newcommand{\@funty}[3]{#2 #1{\funarrow} \, #3}
+\newcommand{\@funty}[3]{#2 \mathbin{#1{\funarrow}} #3}
 
 % \funty is like \@funty but provides a interface.
 %
@@ -707,7 +742,15 @@
 % #2 : The pre-formatted type-variable to bind
 % #3 : The pre-formatted argument to the function
 % #4 : The pre-formatted result of the function
-\newcommand{\@polyfunty}[4]{#1{\forall}\,#1{[}{#2}#1{].}{#3}#1{\funarrow}\,{#4}}
+\newcommand{\@polyfunty}[4]{%
+  \mathpunct{#1{\forall}}% or rather mathopen?
+  \mathopen{#1{[}}
+  #2%
+  \mathclose{#1{].}}\mathpunct{}%
+  #3%
+  \mathbin{#1{\funarrow}}%
+  #4%
+}
 
 % \polyfunty is like \@polyfunty but provides a standard interface.
 %
@@ -723,7 +766,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym
 % #2 : The pre-formatted type-variable to bind
 % #3 : The pre-formatted result in which the type-variable is bound
-\newcommand{\@forallty}[3]{#1{\forall}#2#1{.}\,#3}
+\newcommand{\@forallty}[3]{\@quantifier{#1}{\forall}{#2}{.} #3}
 
 % \forallty is like \@forallty, but provides a standard interface
 %
@@ -738,7 +781,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym
 % #2 : The pre-formatted type-variable to bind
 % #3 : The pre-formatted result in which the type-variable is bound
-\newcommand{\@existty}[3]{#1{\exists}#2#1{.}\,#3}
+\newcommand{\@existty}[3]{\@quantifier{#1}{\exists}{#2}{.} #3}
 
 % \existty is like \@existty but provides a standard interface.
 %
@@ -753,7 +796,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym
 % #2 : The pre-formatted type-variable to bind
 % #3 : The pre-formatted result in which the type-variable is bound
-\newcommand{\@muty}[3]{#1{\upmu} #2 #1{.} #3 }
+\newcommand{\@muty}[3]{\@quantifier{#1}{\upmu}{#2}{.} #3}
 
 % \muty is like \@muty but provides a standard interface.
 %
@@ -801,7 +844,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym
 % #2 : The pre-formatted type for the first component of the pair
 % #3 : The pre-formatted type for the second component of the pair
-\newcommand{\@pairty}[3]{#2 \, #1{\times} \, #3}
+\newcommand{\@pairty}[3]{#2 \mathbin{#1{\times}} #3}
 
 % \pairty is like \@pairty but provides a standard interface.
 %
@@ -816,7 +859,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym
 % #2 : The pre-formatted type for the first component of the sum
 % #3 : The pre-formatted type for the second component of the sum
-\newcommand{\@sumty}[3]{#2 \, #1{\plus} \, #3}
+\newcommand{\@sumty}[3]{#2 \mathbin{#1{\plus}} #3}
 
 % \sumty is like \@sumty but provides a standard interface.
 %
@@ -834,7 +877,11 @@
 % #2 : The pre-formatted variable the function binds.
 % #3 : The pre-formatted type of the variable.
 % #4 : The pre-formatted body of the function.
-\newcommand{\@fune}[4]{#1{\uplambda (}{#2}\,#1{:}\,#3#1{).}\,#4}
+\newcommand{\@fune}[4]{%
+  \mathopen{#1{\uplambda (}}%
+  {#2} \maththinbin{#1{:}} {#3}% \mathbin{:} spacing would be a bit too large
+  \mathclose{#1{).}}%
+  \mathpunct{}#4}
 
 % \fune is like \@fune but provides a standard interface.
 %
@@ -853,7 +900,16 @@
 % #4 : The pre-formatted type of the variable.
 % #5 : The pre-formatted body of the function.
 \newcommand{\@polyfune}[5]{
-  #1{\uplambda}\,#1{[}{#2}#1{]\,(}{#3}\,#1{:}\,#4#1{).}\,#5
+  \mathpunct{#1{\uplambda}}% or rather mathopen? synch with polyfunty
+  \mathopen{#1{[}}%
+  #2%
+  \mathclose{#1{]}}%
+  \mathopen{#1{(}}%
+  #3%
+  \maththinbin{#1{:}}%
+  #4%
+  \mathclose{#1{).}}\mathpunct{}%
+  #5%
 }
 
 % \polyfune is like \@polyfune but provides a standard interface.
@@ -871,7 +927,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym.
 % #2 : The pre-formatted type variable the abstraction binds.
 % #3 : The pre-formatted the body of the abstract.
-\newcommand{\@abstre}[3]{#1{\Uplambda}#2#1{.}#3}
+\newcommand{\@abstre}[3]{\@quantifier{#1}{\Uplambda}{#2}{.} #3}
 
 % \abstre is like \@abstre but provides a standard interface.
 %
@@ -886,7 +942,7 @@
 % #1 : A formatting macro for symbols, such as \tfontsym.
 % #2 : The pre-formatted polymorphic abstraction to instantiate.
 % #3 : The pre-formatted type with which to instantiate the abstraction.
-\newcommand{\@inste}[3]{#2\:#1{[}{#3}#1{]}}
+\newcommand{\@inste}[3]{\@thickinfix{#2} \mathopen{#1{[}} #3 \mathclose{#1{]}}}
 
 % \inste is like \@inste but provides a standard interface.
 %
@@ -916,7 +972,7 @@
 % #2 : A pre-formatted polymorphic function expression.
 % #3 : A pre-formatted type with which to instantiate.
 % #4 : A pre-formatted argument to the function.
-\newcommand{\@pappe}[4]{#2\:#1{[}{#3}#1{]}\:#4}
+\newcommand{\@pappe}[4]{\@thickinfix{\@inste{#1}{#2}{#3}} #4}
 
 % \pappe is like \@pappe but provides a standard interface.
 %
@@ -933,7 +989,7 @@
 % #2 : A pre-formatted discriminant expression.
 % #3 : A pre-formatted consequent expression.
 % #4 : A pre-formatted alternate expression.
-\newcommand{\@ife}[4]{#1{if}\ {#2}\ #1{then}\ {#3}\ #1{else}\ #4}
+\newcommand{\@ife}[4]{\kwopen{#1{if}} #2 \kwbin{#1{then}} #3 \kwbin{#1{else}} #4}
 
 % \ife is like \@ife but provides a standard interface.
 %
@@ -951,8 +1007,11 @@
 % #3 : A pre-formatted type witness.
 % #4 : A pre-formatted value witness.
 % #5 : A pre-formatted existential type abstracting the witness type.
-\newcommand{\@packe}[5]{
-  #1{pack}#2{\langle} #3 #1{,} #4 #2{\rangle}\,#1{as}\,#5
+\newcommand{\@packe}[5]{%
+  \kwopen{#1{pack}}%
+  \@paire{#2}{#3}{#4}%
+  \kwbin{#1{as}}%
+  #5%
 }
 
 % \packe is like \@packe but provides a standard interface.
@@ -972,8 +1031,13 @@
 % #4 : A pre-formatted value variable.
 % #5 : A pre-formatted existential witness expression.
 % #6 : A pre-formatted expression in which to bind the existential.
-\newcommand{\@unpacke}[6]{
-  #1{unpack}#2{\langle}#3 #1{,} #4 #2{\rangle\! = \,} #5 \,#1{in}\, #6
+\newcommand{\@unpacke}[6]{%
+  \kwopen{#1{unpack}}%
+  \@paire{#2}{#3}{#4}%
+  \mathbin{#2{=}}%
+  #5%
+  \kwbin{#1{in}}%
+  #6
 }
 
 % \unpacke is like \@unpacke but provides a standard interface.
@@ -993,7 +1057,13 @@
 % #3 : A pre-formatted expression variable.
 % #4 : A pre-formatted expression to bind.
 % #5 : A pre-formatted body expression for the let.
-\newcommand{\@lete}[5]{#1{let}\ #3\:#2{=}\:{#4}\ #1{in}\ #5}
+\newcommand{\@lete}[5]{%
+  \kwopen{#1{let}}%
+  #3%
+  \mathbin{#2{=}}%
+  #4%
+  \kwbin{#1{in}}%
+  #5}
 
 % \lete is like \@lete but provides a standard interface
 %
@@ -1009,7 +1079,7 @@
 % #1 : A formatting macro for text, such as \tfont.
 % #2 : A pre-formatted mu type.
 % #3 : A pre-formatted expression of isorecursive type.
-\newcommand{\@folde}[3]{#1{fold}_{#2} \, #3}
+\newcommand{\@folde}[3]{\kwinfix{#1{fold}_{#2}} #3}
 
 % \folde is like \@folde but provides a standard interface.
 %
@@ -1023,7 +1093,7 @@
 %
 % #1 : A formatting macro for text, such as \tfont.
 % #2 : A pre-formatted expression of isorecursive type.
-\newcommand{\@unfolde}[2]{#1{unfold} \, #2}
+\newcommand{\@unfolde}[2]{\kwinfix{#1{unfold}} #2}
 
 % \unfolde is like \@unfolde but provides a standard interface.
 %
@@ -1070,7 +1140,13 @@
 % #1 : A formatting macro for symbols, such as \tfontsym.
 % #2 : A pre-formatted expression for the first component of the pair.
 % #3 : A pre-formatted expression for the second component of the pair.
-\newcommand{\@paire}[3]{#1{\langle} #2 \mathpunct{#1,} #3 {#1{\rangle}}}
+\newcommand{\@paire}[3]{%
+  \mathopen{#1{\langle}}%
+  #2%
+  \mathpunct{#1{,}}%
+  #3%
+  \mathclose{{#1{\rangle}}}%
+}
 
 % \paire is like \@paire but provides a standard interface.
 %
@@ -1087,7 +1163,7 @@
 % #3 : An unformatted natural number, either 1 or 2, indicating which
 %   component of the pair to project.
 % #4 : A pre-formatted pair expression to project.
-\newcommand{\@prje}[4]{#1{\pi}_{#2{#3}} \, #4}
+\newcommand{\@prje}[4]{\kwinfix{#1{\pi}_{#2{#3}}} #4}
 
 % \prje is like \@prje but provides a standard interface.
 %
@@ -1105,7 +1181,7 @@
 %   side of the sum to inject the expression. 1 indicates left, 2
 %   indicates right.
 % #3 : A pre-formatted expression to inject into a sum.
-\newcommand{\@sume}[3]{#1{inj}_{#1{#2}} \, #3}
+\newcommand{\@sume}[3]{\kwinfix{#1{inj}_{#1{#2}}} #3}
 
 % \sume is like \@sume but provides a standard interface.
 %
@@ -1125,8 +1201,13 @@
 % #5 : A pre-formatted expression for the left branch.
 % #6 : A pre-formatted variable to bind in the right branch.
 % #7 : A pre-formatted expression for the right branch.
-\newcommand{\@casee}[7]{
-  #1{case} \, #3 \, #1{of} \, #4#2{.}\,#5\:#2{|}\:#6#2{.}\,#7
+\newcommand{\@casee}[7]{%
+  \kwopen{#1{case}}%
+  #3%
+  \kwbin{#1{of}}%
+  #4 \mathpunct{#2{.}} #5%
+  \maththickbin{#2{|}}%
+  #6 \mathpunct{#2{.}} #7
 }
 
 % \casee is like \@casee but provides a standard interface

--- a/test.tex
+++ b/test.tex
@@ -191,6 +191,10 @@
 
   \ctxtyjudg{\tfont}{\tfont{\ectx}}{\tfont{\Gamma}}{\tty}{\tfont{\Gamma}}{\ttypr}
 
+  \ciueqvjudg{\tfont{\Gamma}}{\te}{\tepr}{\tty}
+
+  \ctxeqvjudg{\tfont{\Gamma}}{\te}{\tepr}{\tty}
+
   \rho
 
   \mapat{\rho}{\talpha}
@@ -203,6 +207,7 @@
 
   \mapext{\rho}{\talpha}{\tty}
 
+  \te \bnfdef \tx \bnfalt \tefun \tx \tty \te \bnfalt \teapp \te \tepr
 \end{smathpar}
 
 %{


### PR DESCRIPTION
``` latex
\newcommand{\lete}[5]{%
  \kwopen{#2{let}}%
  #3%
  \mathbin{#1{=}}%
  #4%
  \kwbin{#2{in}}%
  #5%
}

\newcommand{\unfolde}[3]{\kwinfix{#2{unfold}} #3}
```
